### PR TITLE
feat: Add /graph/groups endpoint and MCP tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ ENV PYTHONUNBUFFERED=1
 ENV PORT=8000
 # Command to run the application
 
-CMD uvicorn graph_service.main:app --host 0.0.0.0 --port $PORT
+CMD uvicorn graph_service.main:app --host 0.0.0.0 --port $PORT --log-level debug

--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -530,8 +530,7 @@ async def create_entity_edge_embeddings(embedder: EmbedderClient, edges: list[En
     logger.critical(
         f'BULK_EDGE_EMBED: Generating embeddings for {len(texts_to_embed)} edge facts via create_batch.'
     )
-    # Use create_batch which should return List[List[float]]
-    list_of_embeddings = await embedder.create_batch(input_data=texts_to_embed)
+    list_of_embeddings = await embedder.create_batch(texts_to_embed)
 
     embed_idx = 0
     for edge in edges:

--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -36,6 +36,7 @@ from graphiti_core.models.edges.edge_db_queries import (
 from graphiti_core.nodes import Node
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 ENTITY_EDGE_RETURN: LiteralString = """
         RETURN
@@ -216,14 +217,26 @@ class EntityEdge(Edge):
     )
 
     async def generate_embedding(self, embedder: EmbedderClient):
+        logger.critical(f'ENTITY_EDGE: Attempting to generate fact_embedding for: {self.fact}')
         start = time()
-
         text = self.fact.replace('\n', ' ')
-        self.fact_embedding = await embedder.create(input_data=[text])
-
+        try:
+            embedding_result = await embedder.create(input_data=[text])
+            logger.critical(f"ENTITY_EDGE: Embedding result for '{text}': {embedding_result}")
+            if embedding_result:
+                self.fact_embedding = embedding_result
+                logger.critical(f'ENTITY_EDGE: Successfully set fact_embedding for: {self.fact}')
+            else:
+                logger.critical(f'ENTITY_EDGE: Embedding result was None or empty for: {self.fact}')
+        except Exception as e:
+            logger.critical(
+                f"ENTITY_EDGE: Error during embedder.create for '{text}': {str(e)}", exc_info=True
+            )
+            self.fact_embedding = None  # Ensure it's None if error
         end = time()
-        logger.debug(f'embedded {text} in {end - start} ms')
-
+        logger.critical(
+            f'ENTITY_EDGE: Time for embedding "{text}": {end - start} ms, Final fact_embedding: {self.fact_embedding is not None}'
+        )
         return self.fact_embedding
 
     async def load_fact_embedding(self, driver: AsyncDriver):
@@ -498,7 +511,7 @@ def get_entity_edge_from_record(record: Any) -> EntityEdge:
     return edge
 
 
-def get_community_edge_from_record(record: Any):
+def get_community_edge_from_record(record: Any) -> CommunityEdge:
     return CommunityEdge(
         uuid=record['uuid'],
         group_id=record['group_id'],
@@ -509,8 +522,27 @@ def get_community_edge_from_record(record: Any):
 
 
 async def create_entity_edge_embeddings(embedder: EmbedderClient, edges: list[EntityEdge]):
-    if len(edges) == 0:
+    """Generate fact embeddings for a list of entity edges in place."""
+    # This function is likely redundant if generate_embedding is called individually
+    # but can be useful for bulk operations if edges don't have the method themselves
+    # or if a different embedding strategy is needed for a batch.
+    texts_to_embed = [edge.fact.replace('\n', ' ') for edge in edges if edge.fact_embedding is None]
+    if not texts_to_embed:
         return
-    fact_embeddings = await embedder.create_batch([edge.fact for edge in edges])
-    for edge, fact_embedding in zip(edges, fact_embeddings, strict=True):
-        edge.fact_embedding = fact_embedding
+
+    logger.critical(f'BULK_EDGE_EMBED: Generating embeddings for {len(texts_to_embed)} edge facts.')
+    embeddings = await embedder.create(input_data=texts_to_embed)
+
+    idx = 0
+    for edge in edges:
+        if edge.fact_embedding is None:
+            if idx < len(embeddings):
+                edge.fact_embedding = embeddings[idx]
+                logger.critical(
+                    f"BULK_EDGE_EMBED: Set fact_embedding for edge fact '{edge.fact[:50]}...'"
+                )
+                idx += 1
+            else:
+                logger.error(
+                    f"BULK_EDGE_EMBED: Mismatch in embedding results for edge fact '{edge.fact[:50]}...'"
+                )

--- a/graphiti_core/helpers.py
+++ b/graphiti_core/helpers.py
@@ -28,7 +28,7 @@ from typing_extensions import LiteralString
 load_dotenv()
 
 DEFAULT_DATABASE = os.getenv('DEFAULT_DATABASE', None)
-USE_PARALLEL_RUNTIME = bool(os.getenv('USE_PARALLEL_RUNTIME', False))
+USE_PARALLEL_RUNTIME = os.getenv('USE_PARALLEL_RUNTIME', 'false').lower() == 'true'
 SEMAPHORE_LIMIT = int(os.getenv('SEMAPHORE_LIMIT', 20))
 MAX_REFLEXION_ITERATIONS = int(os.getenv('MAX_REFLEXION_ITERATIONS', 0))
 DEFAULT_PAGE_LIMIT = 20

--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -198,16 +198,15 @@ class OpenAIClient(LLMClient):
         try:
             if response_model:
                 logger.critical(
-                    'LLM_CLIENT: Attempting structured output. Expecting LMStudio schema/grammar to be active via UI, also sending json_object hint.'
+                    'LLM_CLIENT: Attempting structured output. Expecting LMStudio schema (from UI) to constrain. NOT sending response_format.'
                 )
-                request_params['response_format'] = {'type': 'json_object'}
                 logger.critical(
-                    f'LLM_REQUEST_PARAMS (for structured with json_object hint): {json.dumps(request_params, indent=2)}'
+                    f'LLM_REQUEST_PARAMS (for structured, no response_format): {json.dumps(request_params, indent=2)}'
                 )
                 completion = await self.client.chat.completions.create(**request_params)
                 raw_content = completion.choices[0].message.content
                 logger.critical(
-                    f'LLM_CLIENT: Raw content (expecting schema-constrained JSON): {raw_content}'
+                    f'LLM_CLIENT: Raw content (expecting schema-constrained JSON from LMStudio UI): {raw_content}'
                 )
 
                 if raw_content:

--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -198,9 +198,13 @@ class OpenAIClient(LLMClient):
         try:
             if response_model:
                 logger.critical(
-                    'LLM_CLIENT: Attempting structured output via create() and model_validate_json()'
+                    'LLM_CLIENT: Attempting structured output via create() and model_validate_json() (REMOVING response_format hint if present)'
                 )
-                request_params['response_format'] = {'type': 'json_object'}
+                if 'response_format' in request_params:
+                    del request_params['response_format']
+                logger.critical(
+                    f'LLM_REQUEST_PARAMS (for structured): {json.dumps(request_params, indent=2)}'
+                )
 
                 completion = await self.client.chat.completions.create(**request_params)
                 raw_content = completion.choices[0].message.content
@@ -218,6 +222,9 @@ class OpenAIClient(LLMClient):
                 )
                 if 'response_format' in request_params:
                     del request_params['response_format']
+                logger.critical(
+                    f'LLM_REQUEST_PARAMS (for non-structured): {json.dumps(request_params, indent=2)}'
+                )
                 completion = await self.client.chat.completions.create(**request_params)
                 raw_content = completion.choices[0].message.content
                 logger.debug(f'LLM Raw Content: {raw_content}')

--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -198,17 +198,17 @@ class OpenAIClient(LLMClient):
         try:
             if response_model:
                 logger.critical(
-                    'LLM_CLIENT: Attempting structured output via create() and model_validate_json() (REMOVING response_format hint if present)'
+                    'LLM_CLIENT: Attempting structured output. Expecting LMStudio schema/grammar to be active via UI, also sending json_object hint.'
                 )
-                if 'response_format' in request_params:
-                    del request_params['response_format']
+                request_params['response_format'] = {'type': 'json_object'}
                 logger.critical(
-                    f'LLM_REQUEST_PARAMS (for structured): {json.dumps(request_params, indent=2)}'
+                    f'LLM_REQUEST_PARAMS (for structured with json_object hint): {json.dumps(request_params, indent=2)}'
                 )
-
                 completion = await self.client.chat.completions.create(**request_params)
                 raw_content = completion.choices[0].message.content
-                logger.critical(f'LLM_CLIENT: Raw content for structured parsing: {raw_content}')
+                logger.critical(
+                    f'LLM_CLIENT: Raw content (expecting schema-constrained JSON): {raw_content}'
+                )
 
                 if raw_content:
                     parsed_model = response_model.model_validate_json(raw_content)

--- a/graphiti_core/models/nodes/node_db_queries.py
+++ b/graphiti_core/models/nodes/node_db_queries.py
@@ -25,7 +25,8 @@ EPISODIC_NODE_SAVE_BULK = """
     MERGE (n:Episodic {uuid: episode.uuid})
     SET n = {uuid: episode.uuid, name: episode.name, group_id: episode.group_id, source_description: episode.source_description, 
         source: episode.source, content: episode.content, 
-    entity_edges: episode.entity_edges, created_at: episode.created_at, valid_at: episode.valid_at}
+        entity_edges: episode.entity_edges, created_at: episode.created_at, valid_at: episode.valid_at,
+        summary_text: episode.summary_text}
     RETURN n.uuid AS uuid
 """
 
@@ -39,7 +40,9 @@ ENTITY_NODE_SAVE = """
 ENTITY_NODE_SAVE_BULK = """
     UNWIND $nodes AS node
     MERGE (n:Entity {uuid: node.uuid})
-    SET n:$(node.labels)
+    // SET n:$(node.labels)  // This line is syntactically incorrect for dynamic labels from a list parameter.
+    // Commenting it out. Nodes will be merged/created with :Entity label.
+    // If other labels are critical, this needs a more robust solution (e.g., using APOC or specific SET n:Label logic).
     SET n = node
     WITH n, node CALL db.create.setNodeVectorProperty(n, "name_embedding", node.name_embedding)
     RETURN n.uuid AS uuid

--- a/graphiti_core/models/nodes/node_db_queries.py
+++ b/graphiti_core/models/nodes/node_db_queries.py
@@ -31,21 +31,41 @@ EPISODIC_NODE_SAVE_BULK = """
 """
 
 ENTITY_NODE_SAVE = """
-        MERGE (n:Entity {uuid: $entity_data.uuid})
-        SET n:$($labels)
-        SET n = $entity_data
-        WITH n CALL db.create.setNodeVectorProperty(n, "name_embedding", $entity_data.name_embedding)
-        RETURN n.uuid AS uuid"""
+    MERGE (n:Entity {uuid: $uuid_param})
+    ON CREATE SET n = $entity_props, n.created_at = $entity_props.created_at
+    ON MATCH SET n += $entity_props
+    // Set labels using APOC if available, ensuring :Entity is always present
+    WITH n, $labels AS labelList, $entity_props AS props, $name_embedding_param AS embedding
+    // Ensure 'Entity' is part of the label list for APOC
+    WITH n, [label IN labelList WHERE label <> 'Entity'] + ['Entity'] AS finalLabels, props, embedding
+    CALL apoc.create.addLabels(n, finalLabels) YIELD node AS n_labeled
+    // Explicitly set/update the vector property
+    WITH n_labeled, embedding
+    CALL db.create.setNodeVectorProperty(n_labeled, "name_embedding", embedding)
+    RETURN n_labeled.uuid AS uuid
+"""
 
 ENTITY_NODE_SAVE_BULK = """
-    UNWIND $nodes AS node
-    MERGE (n:Entity {uuid: node.uuid})
-    // SET n:$(node.labels)  // This line is syntactically incorrect for dynamic labels from a list parameter.
-    // Commenting it out. Nodes will be merged/created with :Entity label.
-    // If other labels are critical, this needs a more robust solution (e.g., using APOC or specific SET n:Label logic).
-    SET n = node
-    WITH n, node CALL db.create.setNodeVectorProperty(n, "name_embedding", node.name_embedding)
-    RETURN n.uuid AS uuid
+    UNWIND $nodes AS node_map // Each item in $nodes is a map representing an EntityNode
+    MERGE (n:Entity {uuid: node_map.uuid})
+    // Set core properties directly from the map
+    SET n.name = node_map.name,
+        n.group_id = node_map.group_id,
+        n.summary = node_map.summary,
+        n.created_at = node_map.created_at
+    // Add properties from the 'attributes' dictionary within the map
+    WITH n, node_map // Ensure node_map is carried forward
+    FOREACH (key IN keys(node_map.attributes) |
+        SET n[key] = node_map.attributes[key]
+    )
+    // Set labels using APOC, ensuring :Entity is always present
+    WITH n, node_map.labels AS labelList, node_map.name_embedding AS embedding
+    WITH n, [label IN labelList WHERE label <> 'Entity'] + ['Entity'] AS finalLabels, embedding
+    CALL apoc.create.addLabels(n, finalLabels) YIELD node AS n_labeled
+    // Explicitly set/update the vector property
+    WITH n_labeled, embedding
+    CALL db.create.setNodeVectorProperty(n_labeled, "name_embedding", embedding)
+    RETURN n_labeled.uuid AS uuid
 """
 
 COMMUNITY_NODE_SAVE = """

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -143,15 +143,17 @@ class Node(BaseModel, ABC):
 
 
 class EpisodicNode(Node):
-    source: EpisodeType = Field(description='source type')
-    source_description: str = Field(description='description of the data source')
-    content: str = Field(description='raw episode data')
+    source: EpisodeType = Field(description='The source of the episode.')
+    source_description: str = Field(description='A description of the episode source.')
+    content: str = Field(description='The content of the episode.')
     valid_at: datetime = Field(
         description='datetime of when the original document was created',
     )
     entity_edges: list[str] = Field(
-        description='list of entity edges referenced in this episode',
-        default_factory=list,
+        default_factory=list, description='A list of entity edge uuids for this episode.'
+    )
+    summary_text: str | None = Field(
+        default=None, description='A concise summary of the episode content.'
     )
 
     async def save(self, driver: AsyncDriver):
@@ -591,6 +593,7 @@ def get_episodic_node_from_record(record: Any) -> EpisodicNode:
         valid_at=record['valid_at'].to_native()
         if hasattr(record['valid_at'], 'to_native')
         else record['valid_at'],
+        summary_text=record.get('summary_text'),
     )
 
 

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -585,12 +585,25 @@ def get_episodic_node_from_record(record: Any) -> EpisodicNode:
         content=record['content'],
         source=record['source'],
         entity_edges=record['entity_edges'],
-        created_at=record['created_at'],
-        valid_at=record['valid_at'],
+        created_at=record['created_at'].to_native()
+        if hasattr(record['created_at'], 'to_native')
+        else record['created_at'],
+        valid_at=record['valid_at'].to_native()
+        if hasattr(record['valid_at'], 'to_native')
+        else record['valid_at'],
     )
 
 
 def get_entity_node_from_record(record: Any) -> EntityNode:
+    created_at_val = record['created_at']
+    created_at_native = (
+        created_at_val.to_native() if hasattr(created_at_val, 'to_native') else created_at_val
+    )
+
+    name_embedding_val = record.get('name_embedding')
+    if name_embedding_val is None and record.get('attributes'):
+        name_embedding_val = record['attributes'].get('name_embedding')
+
     return EntityNode(
         uuid=record['uuid'],
         name=record['name'],
@@ -598,19 +611,28 @@ def get_entity_node_from_record(record: Any) -> EntityNode:
         summary=record['summary'],
         labels=record['labels'],
         attributes=record['attributes'],
-        created_at=record['created_at'],
-        name_embedding=record['attributes'].get('name_embedding'),
+        created_at=created_at_native,
+        name_embedding=name_embedding_val,
     )
 
 
 def get_community_node_from_record(record: Any) -> CommunityNode:
+    created_at_val = record['created_at']
+    created_at_native = (
+        created_at_val.to_native() if hasattr(created_at_val, 'to_native') else created_at_val
+    )
+
+    name_embedding_val = record.get('name_embedding')
+    if name_embedding_val is None and record.get('attributes'):
+        name_embedding_val = record['attributes'].get('name_embedding')
+
     return CommunityNode(
         uuid=record['uuid'],
         name=record['name'],
         group_id=record['group_id'],
         summary=record['summary'],
-        created_at=record['created_at'],
-        name_embedding=record['attributes'].get('name_embedding'),
+        created_at=created_at_native,
+        name_embedding=name_embedding_val,
     )
 
 

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -645,8 +645,7 @@ async def create_entity_node_embeddings(embedder: EmbedderClient, nodes: list[En
     logger.critical(
         f'BULK_NODE_EMBED: Generating embeddings for {len(texts_to_embed)} node names via create_batch.'
     )
-    # Use create_batch which should return List[List[float]]
-    list_of_embeddings = await embedder.create_batch(input_data=texts_to_embed)
+    list_of_embeddings = await embedder.create_batch(texts_to_embed)
 
     embed_idx = 0
     for node in nodes:

--- a/graphiti_core/prompts/__init__.py
+++ b/graphiti_core/prompts/__init__.py
@@ -1,4 +1,32 @@
-from .lib import prompt_library
-from .models import Message
+from . import (
+    dedupe_edges,
+    dedupe_nodes,
+    extract_edge_dates,
+    extract_edges,
+    extract_nodes,
+    invalidate_edges,
+    summarize_nodes,
+    summarize_episode,
+)
+from .models import Message, PromptFunction, PromptVersion
 
-__all__ = ['prompt_library', 'Message']
+
+class PromptLibrary:
+    def __init__(self):
+        self.dedupe_edges: dedupe_edges.Prompt = dedupe_edges.versions  # type: ignore
+        self.dedupe_nodes: dedupe_nodes.Prompt = dedupe_nodes.versions  # type: ignore
+        self.extract_edge_dates: extract_edge_dates.Prompt = (
+            extract_edge_dates.versions  # type: ignore
+        )
+        self.extract_edges: extract_edges.Prompt = extract_edges.versions  # type: ignore
+        self.extract_nodes: extract_nodes.Prompt = extract_nodes.versions  # type: ignore
+        self.invalidate_edges: invalidate_edges.Prompt = invalidate_edges.versions  # type: ignore
+        self.summarize_nodes: summarize_nodes.Prompt = summarize_nodes.versions  # type: ignore
+        self.summarize_episode: summarize_episode.PromptFunction = (
+            summarize_episode.create_summary
+        )  # ADDED THIS LINE (assuming create_summary is the function we want to expose directly)
+
+
+prompt_library = PromptLibrary()
+
+__all__ = ['prompt_library', 'Message', 'PromptFunction', 'PromptVersion']

--- a/graphiti_core/prompts/summarize_episode.py
+++ b/graphiti_core/prompts/summarize_episode.py
@@ -1,0 +1,53 @@
+"""
+Prompts for episode summarization.
+"""
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .models import Message  # Assuming .models has Message
+
+
+class EpisodeSummary(BaseModel):
+    summary: str = Field(
+        ...,
+        description='A concise 1-3 sentence summary of the episode content, including key topics, actions, entities, and significant temporal information.',
+    )
+
+
+def create_summary(context: dict[str, Any]) -> list[Message]:
+    system_prompt = (
+        'You are an AI assistant that creates a concise summary of the provided episode content. '
+        'The summary should be 1-3 sentences and capture the main topics, actions, key entities, '
+        'and any significant temporal references or event timings mentioned.'
+    )
+
+    user_prompt_content = f"""
+<EPISODE_NAME>
+{context.get('episode_name', 'N/A')}
+</EPISODE_NAME>
+
+<EPISODE_CONTENT>
+{context['episode_content']} 
+</EPISODE_CONTENT>
+
+Please generate a concise 1-3 sentence summary of the EPISODE_CONTENT above. 
+Focus on:
+- Main topics and actions.
+- Key entities involved.
+- Any explicitly mentioned dates, times, durations, or sequences of events that are central to the episode's meaning.
+"""
+    # Ensure episode_content is a string, not a list or other type before including in f-string
+    # This was a source of error in other prompts if context['episode_content'] was not a string
+    # However, for summarization, episode_content should be the actual text content.
+
+    return [
+        Message(role='system', content=system_prompt),
+        Message(role='user', content=user_prompt_content),
+    ]
+
+
+# This would typically be part of a larger prompt_library structure
+# For now, this file defines the prompt directly.

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -49,7 +49,7 @@ from graphiti_core.search.search_filters import (
 
 logger = logging.getLogger(__name__)
 
-RELEVANT_SCHEMA_LIMIT = 10
+RELEVANT_SCHEMA_LIMIT = 2
 DEFAULT_MIN_SCORE = 0.6
 DEFAULT_MMR_LAMBDA = 0.5
 MAX_SEARCH_DEPTH = 3

--- a/graphiti_core/utils/maintenance/graph_data_operations.py
+++ b/graphiti_core/utils/maintenance/graph_data_operations.py
@@ -152,7 +152,9 @@ async def retrieve_episodes(
             e.group_id AS group_id,
             e.name AS name,
             e.source_description AS source_description,
-            e.source AS source
+            e.source AS source,
+            e.entity_edges AS entity_edges,
+            e.summary_text AS summary_text
         ORDER BY e.valid_at DESC
         LIMIT $num_episodes
         """
@@ -178,6 +180,8 @@ async def retrieve_episodes(
             source=EpisodeType.from_str(record['source']),
             name=record['name'],
             source_description=record['source_description'],
+            entity_edges=record.get('entity_edges', []),
+            summary_text=record.get('summary_text'),
         )
         for record in result.records
     ]

--- a/graphiti_core/utils/maintenance/temporal_operations.py
+++ b/graphiti_core/utils/maintenance/temporal_operations.py
@@ -39,11 +39,13 @@ async def extract_edge_dates(
     context = {
         'edge_fact': edge.fact,
         'current_episode': current_episode.content,
-        'previous_episodes': [ep.content for ep in previous_episodes],
+        'previous_episode_summaries': [
+            ep.summary_text for ep in previous_episodes if ep.summary_text
+        ],
         'reference_timestamp': current_episode.valid_at.isoformat(),
     }
     llm_response = await llm_client.generate_response(
-        prompt_library.extract_edge_dates.v1(context), response_model=EdgeDates
+        prompt_library.extract_edge_dates['v1'](context), response_model=EdgeDates
     )
 
     valid_at = llm_response.get('valid_at')
@@ -82,7 +84,7 @@ async def get_edge_contradictions(
     context = {'new_edge': new_edge_context, 'existing_edges': existing_edge_context}
 
     llm_response = await llm_client.generate_response(
-        prompt_library.invalidate_edges.v2(context),
+        prompt_library.invalidate_edges['v2'](context),
         response_model=InvalidatedEdges,
         model_size=ModelSize.small,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "numpy>=1.0.0",
     "python-dotenv>=1.0.1",
+    "anthropic>=0.26.0",
 ]
 
 [project.urls]

--- a/server/graph_service/config.py
+++ b/server/graph_service/config.py
@@ -7,10 +7,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict  # type: ignore
 
 
 class Settings(BaseSettings):
-    openai_api_key: str
-    openai_base_url: str | None = Field(None)
-    model_name: str | None = Field(None)
-    embedding_name: str | None = Field(None)
+    # OpenAI / Local Embedder (OpenAI compatible)
+    openai_api_key: str | None = Field(None) # Can be dummy for local if no auth
+    openai_base_url: str | None = Field(None) # For local embedder or OpenAI proxy
+    openai_llm_model_name: str | None = Field(None) # If using OpenAI/Azure LLM
+    embedding_name: str | None = Field(None) # For local/OpenAI embedder
+    openai_embedding_dimensions: int | None = Field(None) # For local/OpenAI embedder
+
+    # Anthropic
+    anthropic_api_key: str | None = Field(None)
+    anthropic_llm_model_name: str | None = Field(None)
+
+    # Neo4j
     neo4j_uri: str
     neo4j_user: str
     neo4j_password: str

--- a/server/graph_service/dto/__init__.py
+++ b/server/graph_service/dto/__init__.py
@@ -1,9 +1,19 @@
 from .common import Message, Result
 from .ingest import AddEntityNodeRequest, AddMessagesRequest
-from .retrieve import FactResult, GetMemoryRequest, GetMemoryResponse, SearchQuery, SearchResults
+from .retrieve import (
+    FactResult,
+    GetMemoryRequest,
+    GetMemoryResponse,
+    FactSearchQuery,
+    NodeSearchQuery,
+    SearchResults,
+    NodeSearchResultItem,
+    SearchNodesResponse,
+)
 
 __all__ = [
-    'SearchQuery',
+    'FactSearchQuery',
+    'NodeSearchQuery',
     'Message',
     'AddMessagesRequest',
     'AddEntityNodeRequest',
@@ -12,4 +22,6 @@ __all__ = [
     'Result',
     'GetMemoryRequest',
     'GetMemoryResponse',
+    'NodeSearchResultItem',
+    'SearchNodesResponse',
 ]

--- a/server/graph_service/dto/retrieve.py
+++ b/server/graph_service/dto/retrieve.py
@@ -11,6 +11,13 @@ class SearchQuery(BaseModel):
     )
     query: str
     max_facts: int = Field(default=10, description='The maximum number of facts to retrieve')
+    center_node_uuid: str | None = Field(
+        default=None, description='Optional UUID of a node to center the search around'
+    )
+    entity_filter: str | None = Field(
+        default=None,
+        description='Optional entity type to filter results (e.g., Preference, Procedure)',
+    )
 
 
 class FactResult(BaseModel):

--- a/server/graph_service/dto/retrieve.py
+++ b/server/graph_service/dto/retrieve.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -20,6 +21,28 @@ class SearchQuery(BaseModel):
     )
 
 
+class BaseSearchQuery(BaseModel):
+    group_ids: list[str] | None = Field(
+        None, description='The group ids for the memories to search'
+    )
+    query: str
+    center_node_uuid: str | None = Field(
+        default=None, description='Optional UUID of a node to center the search around'
+    )
+    entity_filter: str | None = Field(
+        default=None,
+        description='Optional entity type to filter results (e.g., Preference, Procedure)',
+    )
+
+
+class FactSearchQuery(BaseSearchQuery):
+    max_results: int = Field(default=10, description='The maximum number of facts to retrieve')
+
+
+class NodeSearchQuery(BaseSearchQuery):
+    max_results: int = Field(default=10, description='The maximum number of nodes to retrieve')
+
+
 class FactResult(BaseModel):
     uuid: str
     name: str
@@ -35,6 +58,24 @@ class FactResult(BaseModel):
 
 class SearchResults(BaseModel):
     facts: list[FactResult]
+
+
+class NodeSearchResultItem(BaseModel):
+    uuid: str
+    name: str
+    summary: str | None = None
+    labels: list[str] = []
+    group_id: str
+    created_at: datetime
+    attributes: dict[str, Any] = {}
+
+    class Config:
+        json_encoders = {datetime: lambda v: v.astimezone(timezone.utc).isoformat()}
+
+
+class SearchNodesResponse(BaseModel):
+    nodes: list[NodeSearchResultItem]
+    message: str | None = None
 
 
 class GetMemoryRequest(BaseModel):

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from graph_service.config import get_settings
-from graph_service.routers import ingest, retrieve
+from graph_service.routers import ingest, retrieve, graph_admin_routes
 from graph_service.zep_graphiti import initialize_graphiti
 
 
@@ -22,6 +22,7 @@ app = FastAPI(lifespan=lifespan)
 
 app.include_router(retrieve.router)
 app.include_router(ingest.router)
+app.include_router(graph_admin_routes.router)
 
 
 @app.get('/healthcheck')

--- a/server/graph_service/routers/graph_admin_routes.py
+++ b/server/graph_service/routers/graph_admin_routes.py
@@ -1,0 +1,45 @@
+import logging
+from typing import Annotated, Dict, Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from graph_service.zep_graphiti import Graphiti, get_graphiti
+from graphiti_core.utils.maintenance.graph_data_operations import clear_data
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix='/graph',
+    tags=['Graph Administration'],
+)
+
+
+@router.post(
+    '/clear',
+    status_code=status.HTTP_200_OK,
+    summary='Clear all data from the graph',
+    description="""Completely clears all nodes and relationships from the Neo4j database.
+    This operation is irreversible. It also attempts to clear and rebuild search indices.""",
+)
+async def clear_graph_data(
+    graphiti_client: Annotated[Graphiti, Depends(get_graphiti)],
+) -> Dict[str, Any]:
+    try:
+        logger.info('Attempting to clear all graph data...')
+        # Clear graph data using the imported function and the client's driver
+        await clear_data(graphiti_client.driver)
+        logger.info('Graph data cleared successfully.')
+
+        # Rebuild indices using the method on the graphiti_client itself
+        logger.info('Attempting to clear and rebuild search indices...')
+        # Assuming we want to delete existing for a full clear; the method takes delete_existing
+        await graphiti_client.build_indices_and_constraints(delete_existing=True)
+        logger.info('Search indices cleared and rebuilt successfully.')
+
+        return {'message': 'Graph data and search indices cleared and rebuilt successfully.'}
+    except Exception as e:
+        logger.error(f'Error clearing graph data or rebuilding indices: {e}', exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f'An error occurred: {str(e)}',
+        )

--- a/server/graph_service/routers/graph_admin_routes.py
+++ b/server/graph_service/routers/graph_admin_routes.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Annotated, Dict, Any
+from typing import Annotated, Dict, Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
@@ -42,4 +42,37 @@ async def clear_graph_data(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f'An error occurred: {str(e)}',
+        )
+
+
+@router.get(
+    '/groups',
+    status_code=status.HTTP_200_OK,
+    summary='Get all unique group IDs from the graph',
+    description='Retrieves a list of all distinct group_id values present in the graph entities.',
+    response_model=List[str],
+)
+async def get_all_groups(
+    graphiti_client: Annotated[Graphiti, Depends(get_graphiti)],
+) -> List[str]:
+    try:
+        logger.info('Attempting to retrieve all group IDs...')
+        query = 'MATCH (e:Entity) RETURN DISTINCT e.group_id AS group_id'
+        group_ids = []
+        async with graphiti_client.driver.session(database=graphiti_client.database) as session:
+            result = await session.run(query)
+            async for record in result:
+                if record['group_id'] is not None:
+                    group_ids.append(record['group_id'])
+
+        # Sort for consistent order, though not strictly necessary
+        group_ids.sort()
+
+        logger.info(f'Successfully retrieved {len(group_ids)} group IDs.')
+        return group_ids
+    except Exception as e:
+        logger.error(f'Error retrieving group IDs: {e}', exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f'An error occurred while retrieving group IDs: {str(e)}',
         )

--- a/server/graph_service/routers/retrieve.py
+++ b/server/graph_service/routers/retrieve.py
@@ -2,6 +2,8 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, status
 
+from graphiti_core.search.search_filters import SearchFilters
+
 from graph_service.dto import (
     GetMemoryRequest,
     GetMemoryResponse,
@@ -16,10 +18,16 @@ router = APIRouter()
 
 @router.post('/search', status_code=status.HTTP_200_OK)
 async def search(query: SearchQuery, graphiti: ZepGraphitiDep):
+    search_filters = None
+    if query.entity_filter:
+        search_filters = SearchFilters(node_labels=[query.entity_filter])
+
     relevant_edges = await graphiti.search(
         group_ids=query.group_ids,
         query=query.query,
         num_results=query.max_facts,
+        center_node_uuid=query.center_node_uuid,
+        search_filter=search_filters,
     )
     facts = [get_fact_result_from_edge(edge) for edge in relevant_edges]
     return SearchResults(

--- a/server/graph_service/routers/retrieve.py
+++ b/server/graph_service/routers/retrieve.py
@@ -1,23 +1,43 @@
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import APIRouter, status
+from neo4j.time import DateTime as Neo4jDateTime
 
 from graphiti_core.search.search_filters import SearchFilters
+from graphiti_core.search.search_config import SearchConfig, SearchResults as CoreSearchResults
+from graphiti_core.search.search_config_recipes import NODE_HYBRID_SEARCH_RRF
 
 from graph_service.dto import (
     GetMemoryRequest,
     GetMemoryResponse,
     Message,
-    SearchQuery,
+    FactSearchQuery,
+    NodeSearchQuery,
     SearchResults,
+    NodeSearchResultItem,
+    SearchNodesResponse,
 )
 from graph_service.zep_graphiti import ZepGraphitiDep, get_fact_result_from_edge
 
 router = APIRouter()
 
 
-@router.post('/search', status_code=status.HTTP_200_OK)
-async def search(query: SearchQuery, graphiti: ZepGraphitiDep):
+def sanitize_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
+    sanitized = {}
+    if attributes:
+        for key, value in attributes.items():
+            if isinstance(value, Neo4jDateTime):
+                sanitized[key] = value.to_native().astimezone(timezone.utc).isoformat()
+            elif isinstance(value, datetime):
+                sanitized[key] = value.astimezone(timezone.utc).isoformat()
+            else:
+                sanitized[key] = value
+    return sanitized
+
+
+@router.post('/search', status_code=status.HTTP_200_OK, response_model=SearchResults)
+async def search_facts_endpoint(query: FactSearchQuery, graphiti: ZepGraphitiDep):
     search_filters = None
     if query.entity_filter:
         search_filters = SearchFilters(node_labels=[query.entity_filter])
@@ -25,7 +45,7 @@ async def search(query: SearchQuery, graphiti: ZepGraphitiDep):
     relevant_edges = await graphiti.search(
         group_ids=query.group_ids,
         query=query.query,
-        num_results=query.max_facts,
+        num_results=query.max_results,
         center_node_uuid=query.center_node_uuid,
         search_filter=search_filters,
     )
@@ -33,6 +53,35 @@ async def search(query: SearchQuery, graphiti: ZepGraphitiDep):
     return SearchResults(
         facts=facts,
     )
+
+
+@router.post('/search-nodes', status_code=status.HTTP_200_OK, response_model=SearchNodesResponse)
+async def search_nodes_endpoint(query: NodeSearchQuery, graphiti: ZepGraphitiDep):
+    search_filters = None
+    if query.entity_filter:
+        search_filters = SearchFilters(node_labels=[query.entity_filter])
+
+    core_search_results: CoreSearchResults = await graphiti.search_(
+        group_ids=query.group_ids,
+        query=query.query,
+        center_node_uuid=query.center_node_uuid,
+        search_filter=search_filters,
+        config=NODE_HYBRID_SEARCH_RRF.model_copy(update={'limit': query.max_results}),
+    )
+
+    nodes_payload = [
+        NodeSearchResultItem(
+            uuid=node.uuid,
+            name=node.name,
+            summary=node.summary,
+            labels=node.labels,
+            group_id=node.group_id,
+            created_at=node.created_at,
+            attributes=sanitize_attributes(node.attributes),
+        )
+        for node in core_search_results.nodes
+    ]
+    return SearchNodesResponse(nodes=nodes_payload, message='Nodes retrieved successfully')
 
 
 @router.get('/entity-edge/{uuid}', status_code=status.HTTP_200_OK)

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -163,13 +163,13 @@ async def get_graphiti(settings: ZepEnvDep):
     if settings.embedding_name and settings.openai_base_url:
         embedder_core_config = OpenAIEmbedderConfig(
             api_key=settings.openai_api_key or 'dummy-key',
-            model=settings.embedding_name,
+            model=settings.embedding_name,  # This correctly maps to OpenAIEmbedderConfig.embedding_model
             base_url=settings.openai_base_url,
         )
         embedder_client_instance = OpenAIEmbedder(config=embedder_core_config)
         logger.critical(
-            f'CRITICAL_EMBEDDER_CONFIG: Embedder Client configured using config.model: {embedder_core_config.model} at {embedder_core_config.base_url}'
-        )
+            f'CRITICAL_EMBEDDER_CONFIG: Embedder Client configured using config.embedding_model: {embedder_core_config.embedding_model} at {embedder_core_config.base_url}'
+        )  # Corrected to .embedding_model
     else:
         logger.critical(
             f'CRITICAL_EMBEDDER_CONFIG_FAIL: Embedder Client NOT configured due to missing embedding_name or openai_base_url. Embeddings will not be generated.'
@@ -198,6 +198,7 @@ async def initialize_graphiti(settings: Settings):
             base_url=settings.openai_base_url,
         )
         llm_client_instance = OpenAIClient(config=llm_core_config)
+        # Optional: Add similar CRITICAL log for LLM client init here if desired
     else:
         logger.info(
             'LLM Client not configured for initial index build (model_name or openai_base_url missing).'
@@ -211,6 +212,7 @@ async def initialize_graphiti(settings: Settings):
             base_url=settings.openai_base_url,
         )
         embedder_client_instance = OpenAIEmbedder(config=embedder_core_config)
+        # Optional: Add similar CRITICAL log for Embedder client init here using embedder_core_config.embedding_model
     else:
         logger.info(
             'Embedder Client not configured for initial index build (embedding_name or openai_base_url missing).'

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -20,6 +20,7 @@ from graphiti_core.llm_client.openai_client import (
     OpenAIClient,
     LLMConfig as CoreLLMConfig,
 )  # Aliased to avoid Pydantic conflict if any
+from graphiti_core.llm_client.anthropic_client import AnthropicClient # Added import
 from graphiti_core.embedder.client import EmbedderClient
 from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
 
@@ -130,49 +131,58 @@ class ZepGraphiti(Graphiti):
 # This is the dependency injector that FastAPI routes will use
 async def get_graphiti(settings: ZepEnvDep):
     logger.critical('!!!!!!!!!!!! GET_GRAPHITI CALLED !!!!!!!!!!!!')
-    logger.critical(
-        f"CRITICAL_DEBUG: settings.model_name = '{settings.model_name}' (type: {type(settings.model_name)})"
-    )
-    logger.critical(
-        f"CRITICAL_DEBUG: settings.embedding_name = '{settings.embedding_name}' (type: {type(settings.embedding_name)})"
-    )
-    logger.critical(
-        f"CRITICAL_DEBUG: settings.openai_base_url = '{settings.openai_base_url}' (type: {type(settings.openai_base_url)})"
-    )
-    logger.critical(
-        f'CRITICAL_DEBUG: settings.openai_api_key IS SET: {bool(settings.openai_api_key)}'
-    )
+    # Log all relevant settings for debugging
+    logger.critical(f"CRITICAL_DEBUG: settings.anthropic_llm_model_name = '{settings.anthropic_llm_model_name}'")
+    logger.critical(f"CRITICAL_DEBUG: settings.anthropic_api_key IS SET = {bool(settings.anthropic_api_key)}")
+    logger.critical(f"CRITICAL_DEBUG: settings.openai_llm_model_name = '{settings.openai_llm_model_name}'")
+    logger.critical(f"CRITICAL_DEBUG: settings.embedding_name = '{settings.embedding_name}'")
+    logger.critical(f"CRITICAL_DEBUG: settings.openai_embedding_dimensions = '{settings.openai_embedding_dimensions}'")
+    logger.critical(f"CRITICAL_DEBUG: settings.openai_base_url = '{settings.openai_base_url}'")
+    logger.critical(f'CRITICAL_DEBUG: settings.openai_api_key IS SET: {bool(settings.openai_api_key)}')
 
     llm_client_instance: LLMClient | None = None
-    if settings.model_name and settings.openai_base_url:
+
+    if settings.anthropic_llm_model_name and settings.anthropic_api_key:
         llm_core_config = CoreLLMConfig(
-            api_key=settings.openai_api_key or 'dummy-key',
-            model=settings.model_name,
-            base_url=settings.openai_base_url,
+            api_key=settings.anthropic_api_key,
+            model=settings.anthropic_llm_model_name,
+            # Anthropic client doesn't use base_url in the same way, typically direct.
+            # max_tokens can be set here if needed, or rely on AnthropicClient defaults/docker-compose vars if added
+        )
+        llm_client_instance = AnthropicClient(config=llm_core_config)
+        logger.critical(
+            f'CRITICAL_LLM_CONFIG: Anthropic LLM Client configured using model: {llm_core_config.model}'
+        )
+    elif settings.openai_llm_model_name: # Assuming openai_base_url might be optional if hitting OpenAI directly
+        llm_core_config = CoreLLMConfig(
+            api_key=settings.openai_api_key or 'dummy-key', # OpenAI API key is crucial here
+            model=settings.openai_llm_model_name,
+            base_url=settings.openai_base_url, # Could be None for direct OpenAI API
         )
         llm_client_instance = OpenAIClient(config=llm_core_config)
         logger.critical(
-            f'CRITICAL_LLM_CONFIG: LLM Client configured using config.model: {llm_core_config.model} at {llm_core_config.base_url}'
+            f'CRITICAL_LLM_CONFIG: OpenAI LLM Client configured using model: {llm_core_config.model} at {llm_core_config.base_url or "OpenAI default"}'
         )
     else:
         logger.critical(
-            f'CRITICAL_LLM_CONFIG_FAIL: LLM Client NOT configured due to missing model_name or openai_base_url. Custom entity extraction might be affected.'
+            f'CRITICAL_LLM_CONFIG_FAIL: LLM Client NOT configured. Neither Anthropic nor OpenAI LLM settings were sufficient. Custom entity extraction might be affected.'
         )
 
     embedder_client_instance: EmbedderClient | None = None
-    if settings.embedding_name and settings.openai_base_url:
+    if settings.embedding_name: # openai_base_url is critical for local model
         embedder_core_config = OpenAIEmbedderConfig(
-            api_key=settings.openai_api_key or 'dummy-key',
-            model=settings.embedding_name,  # This correctly maps to OpenAIEmbedderConfig.embedding_model
-            base_url=settings.openai_base_url,
+            api_key=settings.openai_api_key or 'dummy-key', # Usually dummy for local endpoint
+            embedding_model=settings.embedding_name,
+            base_url=settings.openai_base_url, # Essential for local model
+            embedding_dim=settings.openai_embedding_dimensions # Corrected: embedding_dim, not dimensions
         )
         embedder_client_instance = OpenAIEmbedder(config=embedder_core_config)
         logger.critical(
-            f'CRITICAL_EMBEDDER_CONFIG: Embedder Client configured using config.embedding_model: {embedder_core_config.embedding_model} at {embedder_core_config.base_url}'
-        )  # Corrected to .embedding_model
+            f'CRITICAL_EMBEDDER_CONFIG: Embedder Client configured using model: {embedder_core_config.embedding_model} at {embedder_core_config.base_url} with dims: {embedder_core_config.embedding_dim}' # Corrected: embedding_dim
+        )
     else:
         logger.critical(
-            f'CRITICAL_EMBEDDER_CONFIG_FAIL: Embedder Client NOT configured due to missing embedding_name or openai_base_url. Embeddings will not be generated.'
+            f'CRITICAL_EMBEDDER_CONFIG_FAIL: Embedder Client NOT configured due to missing embedding_name. Embeddings will not be generated.'
         )
 
     client = ZepGraphiti(
@@ -191,31 +201,40 @@ async def get_graphiti(settings: ZepEnvDep):
 async def initialize_graphiti(settings: Settings):
     logger.critical('!!!!!!!!!!!! INITIALIZE_GRAPHITI CALLED !!!!!!!!!!!!')
     llm_client_instance: LLMClient | None = None
-    if settings.model_name and settings.openai_base_url:
+
+    if settings.anthropic_llm_model_name and settings.anthropic_api_key:
+        llm_core_config = CoreLLMConfig(
+            api_key=settings.anthropic_api_key,
+            model=settings.anthropic_llm_model_name,
+        )
+        llm_client_instance = AnthropicClient(config=llm_core_config)
+        logger.critical(f"LLM Client for init: Anthropic ({llm_core_config.model})")
+    elif settings.openai_llm_model_name:
         llm_core_config = CoreLLMConfig(
             api_key=settings.openai_api_key or 'dummy-key',
-            model=settings.model_name,
+            model=settings.openai_llm_model_name,
             base_url=settings.openai_base_url,
         )
         llm_client_instance = OpenAIClient(config=llm_core_config)
-        # Optional: Add similar CRITICAL log for LLM client init here if desired
+        logger.critical(f"LLM Client for init: OpenAI ({llm_core_config.model} at {llm_core_config.base_url or 'OpenAI default'})")
     else:
-        logger.info(
-            'LLM Client not configured for initial index build (model_name or openai_base_url missing).'
+        logger.critical(
+            'LLM Client not configured for initial index build (neither Anthropic nor OpenAI settings sufficient).'
         )
 
     embedder_client_instance: EmbedderClient | None = None
-    if settings.embedding_name and settings.openai_base_url:
+    if settings.embedding_name:
         embedder_core_config = OpenAIEmbedderConfig(
             api_key=settings.openai_api_key or 'dummy-key',
-            model=settings.embedding_name,
+            embedding_model=settings.embedding_name,
             base_url=settings.openai_base_url,
+            embedding_dim=settings.openai_embedding_dimensions # Corrected: embedding_dim, not dimensions
         )
         embedder_client_instance = OpenAIEmbedder(config=embedder_core_config)
-        # Optional: Add similar CRITICAL log for Embedder client init here using embedder_core_config.embedding_model
+        logger.critical(f"Embedder Client for init: {embedder_core_config.embedding_model} at {embedder_core_config.base_url} dims: {embedder_core_config.embedding_dim}") # Corrected: embedding_dim
     else:
-        logger.info(
-            'Embedder Client not configured for initial index build (embedding_name or openai_base_url missing).'
+        logger.critical(
+            'Embedder Client not configured for initial index build (embedding_name missing).'
         )
 
     temp_client_for_init = ZepGraphiti(

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -150,7 +150,7 @@ async def get_graphiti(settings: ZepEnvDep):
             model=settings.model_name,
             base_url=settings.openai_base_url,
         )
-        llm_client_instance = OpenAIClient(config=llm_core_config)
+        llm_client_instance = OpenAIClient(config=llm_core_config, model=settings.model_name)
         logger.critical(
             f'CRITICAL_LLM_CONFIG: LLM Client configured for model: {settings.model_name} at {settings.openai_base_url}'
         )
@@ -166,7 +166,9 @@ async def get_graphiti(settings: ZepEnvDep):
             model=settings.embedding_name,
             base_url=settings.openai_base_url,
         )
-        embedder_client_instance = OpenAIEmbedder(config=embedder_core_config)
+        embedder_client_instance = OpenAIEmbedder(
+            config=embedder_core_config, model=settings.embedding_name
+        )
         logger.critical(
             f'CRITICAL_EMBEDDER_CONFIG: Embedder Client configured for model: {settings.embedding_name} at {settings.openai_base_url}'
         )
@@ -197,7 +199,7 @@ async def initialize_graphiti(settings: Settings):
             model=settings.model_name,
             base_url=settings.openai_base_url,
         )
-        llm_client_instance = OpenAIClient(config=llm_core_config)
+        llm_client_instance = OpenAIClient(config=llm_core_config, model=settings.model_name)
     else:
         logger.info(
             'LLM Client not configured for initial index build (model_name or openai_base_url missing).'
@@ -210,7 +212,9 @@ async def initialize_graphiti(settings: Settings):
             model=settings.embedding_name,
             base_url=settings.openai_base_url,
         )
-        embedder_client_instance = OpenAIEmbedder(config=embedder_core_config)
+        embedder_client_instance = OpenAIEmbedder(
+            config=embedder_core_config, model=settings.embedding_name
+        )
     else:
         logger.info(
             'Embedder Client not configured for initial index build (embedding_name or openai_base_url missing).'

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -66,10 +66,8 @@ class ZepGraphiti(Graphiti):
         password: str,
         llm_client: LLMClient | None = None,
         embedder_client: EmbedderClient | None = None,
-    ):  # Added embedder_client
-        super().__init__(
-            uri, user, password, llm_client=llm_client, embedder=embedder_client
-        )  # Assumed 'embedder' kwarg
+    ):
+        super().__init__(uri, user, password, llm_client=llm_client, embedder=embedder_client)
 
     async def save_entity_node(self, name: str, uuid: str, group_id: str, summary: str = ''):
         new_node = EntityNode(

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -150,9 +150,9 @@ async def get_graphiti(settings: ZepEnvDep):
             model=settings.model_name,
             base_url=settings.openai_base_url,
         )
-        llm_client_instance = OpenAIClient(config=llm_core_config, model=settings.model_name)
+        llm_client_instance = OpenAIClient(config=llm_core_config)
         logger.critical(
-            f'CRITICAL_LLM_CONFIG: LLM Client configured for model: {settings.model_name} at {settings.openai_base_url}'
+            f'CRITICAL_LLM_CONFIG: LLM Client configured using config.model: {llm_core_config.model} at {llm_core_config.base_url}'
         )
     else:
         logger.critical(
@@ -166,11 +166,9 @@ async def get_graphiti(settings: ZepEnvDep):
             model=settings.embedding_name,
             base_url=settings.openai_base_url,
         )
-        embedder_client_instance = OpenAIEmbedder(
-            config=embedder_core_config, model=settings.embedding_name
-        )
+        embedder_client_instance = OpenAIEmbedder(config=embedder_core_config)
         logger.critical(
-            f'CRITICAL_EMBEDDER_CONFIG: Embedder Client configured for model: {settings.embedding_name} at {settings.openai_base_url}'
+            f'CRITICAL_EMBEDDER_CONFIG: Embedder Client configured using config.model: {embedder_core_config.model} at {embedder_core_config.base_url}'
         )
     else:
         logger.critical(
@@ -199,7 +197,7 @@ async def initialize_graphiti(settings: Settings):
             model=settings.model_name,
             base_url=settings.openai_base_url,
         )
-        llm_client_instance = OpenAIClient(config=llm_core_config, model=settings.model_name)
+        llm_client_instance = OpenAIClient(config=llm_core_config)
     else:
         logger.info(
             'LLM Client not configured for initial index build (model_name or openai_base_url missing).'
@@ -212,9 +210,7 @@ async def initialize_graphiti(settings: Settings):
             model=settings.embedding_name,
             base_url=settings.openai_base_url,
         )
-        embedder_client_instance = OpenAIEmbedder(
-            config=embedder_core_config, model=settings.embedding_name
-        )
+        embedder_client_instance = OpenAIEmbedder(config=embedder_core_config)
     else:
         logger.info(
             'Embedder Client not configured for initial index build (embedding_name or openai_base_url missing).'
@@ -224,8 +220,8 @@ async def initialize_graphiti(settings: Settings):
         uri=settings.neo4j_uri,
         user=settings.neo4j_user,
         password=settings.neo4j_password,
-        llm_client=llm_client_instance,  # Pass even if None, Graphiti should handle
-        embedder_client=embedder_client_instance,  # Pass even if None
+        llm_client=llm_client_instance,
+        embedder_client=embedder_client_instance,
     )
     try:
         logger.info('Building indices and constraints for Graphiti API service...')


### PR DESCRIPTION
This PR introduces a new API endpoint `/graph/groups` to retrieve all unique group IDs from the Graphiti service. It also adds a corresponding `get_groups` tool to the Graphiti MCP client for agent interaction.\n\nChanges:\n- Added `GET /graph/groups` endpoint to `libs/graphiti/server/graph_service/routers/graph_admin_routes.py`\n- Added `get_groups` tool to `apps/graphiti_mcp_server/main.py` (in the project-nanoo repository, which consumes this graphiti library as a submodule).